### PR TITLE
Packet: change NPC name max size to 40 bytes for GCAddNPC packet

### DIFF
--- a/Client/Packet/Gpackets/GCAddNPC.cpp
+++ b/Client/Packet/Gpackets/GCAddNPC.cpp
@@ -29,7 +29,7 @@ void GCAddNPC::read ( SocketInputStream & iStream )
 	if ( szName == 0 )
 		throw InvalidProtocolException("szName == 0");
 
-	if ( szName > 20 )
+	if ( szName > 40 )
 		throw InvalidProtocolException("too large name length");
 		
 	iStream.read( m_Name , szName );
@@ -64,7 +64,7 @@ void GCAddNPC::write ( SocketOutputStream & oStream ) const
 	if ( szName == 0 )
 		throw InvalidProtocolException("szName == 0");
 
-	if ( szName > 20 )
+	if ( szName > 40 )
 		throw InvalidProtocolException("too large name length");
 
 	oStream.write( szName );

--- a/Client/Packet/Gpackets/GCAddNPC.h
+++ b/Client/Packet/Gpackets/GCAddNPC.h
@@ -151,7 +151,7 @@ public :
 	PacketSize_t getPacketMaxSize () const throw () 
 	{
 		return szObjectID 
-			+ szBYTE + 20 + szNPCID
+			+ szBYTE + 40 + szNPCID
 			+ szSpriteType 
 			+ szColor + szColor
 			+ szCoord + szCoord + szDir;


### PR DESCRIPTION
Fix for https://github.com/opendarkeden/server/issues/21

When the database file converted to utf8, it takes more bytes.
For example, 20 bytes is not enough for `海克西里乌斯分身1`, so change it to 40 bytes.

