### PR TITLE
LCLoginOKHandler: ignore teen version setting from the server

### DIFF
--- a/Client/Packet/Lpackets/LCLoginOKHandler.cpp
+++ b/Client/Packet/Lpackets/LCLoginOKHandler.cpp
@@ -123,8 +123,9 @@ void LCLoginOKHandler::execute ( LCLoginOK * pPacket , Player * pPlayer )
 //		if(g_pUserInformation->IsNetmarble)
 //			bGoreLevel = g_pUserInformation->bNetmarbleGoreLevel && !g_pUserOption->UseTeenVersion;
 //		else
-		bGoreLevel = pPacket->isAdult() && !g_pUserOption->UseTeenVersion;
-
+//		By tiancaiamao:
+//		bGoreLevel = pPacket->isAdult() && !g_pUserOption->UseTeenVersion;
+		bGoreLevel = !g_pUserOption->UseTeenVersion;
 
 		g_pUserInformation->GoreLevel = bGoreLevel;
 

--- a/Client/Packet/SocketInputStream.cpp
+++ b/Client/Packet/SocketInputStream.cpp
@@ -784,7 +784,7 @@ WORD SocketInputStream::EncryptData(WORD EncryptKey, char* buf, int len)
 // add by tiancaiamao
 uint receiveWithDebug (Socket *pSock, void * buf , uint len) {
 	uint ret = pSock->receive(buf,len); 
-
+/*
 	#ifdef __DEBUG_OUTPUT__
 		if (ret > 0) {
 			FILE* fp = fopen("fill.log", "a");
@@ -795,6 +795,6 @@ uint receiveWithDebug (Socket *pSock, void * buf , uint len) {
 			fclose(fp);
 		}
 	#endif
-
+*/
 	return ret;
 }


### PR DESCRIPTION
In `LCLoginOKHandler`, the client will receive a information about whether it should display teen version.

I don't like the teen version... ignore this setting ...