### PR TITLE
*: make UserOption file human readable & disable auto use potion

### DIFF
--- a/Client/GameUI.cpp
+++ b/Client/GameUI.cpp
@@ -2927,7 +2927,6 @@ UI_SetHP(int current, int max)
 		}
 		lastPercent = percent;
 
-		DEBUG_ADD_FORMAT("[UI] USE POTION Set HP  (%d / %d)", current, max);
 	__END_HELP_EVENT
 
 	DEBUG_ADD_FORMAT("[UI] Set HP  (%d / %d)", current, max);

--- a/Client/GameUI.cpp
+++ b/Client/GameUI.cpp
@@ -2915,7 +2915,7 @@ UI_SetHP(int current, int max)
 	//---------------------------------------------------------------
 	// HP 낮은 경우 체크
 	//---------------------------------------------------------------
-//	__BEGIN_HELP_EVENT
+	__BEGIN_HELP_EVENT
 		static int lastPercent = 100;
 		int percent = ((max==0)?0 : current*100 / max);
 
@@ -2926,7 +2926,9 @@ UI_SetHP(int current, int max)
 			ExecuteHelpEvent( HELP_EVENT_USE_POTION );
 		}
 		lastPercent = percent;
-//	__END_HELP_EVENT
+
+		DEBUG_ADD_FORMAT("[UI] USE POTION Set HP  (%d / %d)", current, max);
+	__END_HELP_EVENT
 
 	DEBUG_ADD_FORMAT("[UI] Set HP  (%d / %d)", current, max);
 	
@@ -3001,7 +3003,7 @@ UI_SetMP(int current, int max)
 	//---------------------------------------------------------------
 	// MP 낮은 경우 체크
 	//---------------------------------------------------------------
-//	__BEGIN_HELP_EVENT
+	__BEGIN_HELP_EVENT
 		static int lastPercent = 100;
 		int percent = ((max==0)?0 : current*100 / max);
 
@@ -3014,8 +3016,7 @@ UI_SetMP(int current, int max)
 
 			lastPercent = percent;
 		}
-		
-//	__END_HELP_EVENT
+	__END_HELP_EVENT
 
 	DEBUG_ADD_FORMAT("[UI] Set MP  (%d / %d)", current, max);
 	

--- a/Client/MTestDef.h
+++ b/Client/MTestDef.h
@@ -7,10 +7,9 @@
 
 #include "DebugInfo.h"
 
-	// 사내 테스트 버전 만들때..
-	#ifdef OUTPUT_DEBUG
-		#define __METROTECH_TEST__
-	#endif
+	// #ifdef OUTPUT_DEBUG
+	//	#define __METROTECH_TEST__
+	// #endif
 
 	#ifdef __METROTECH_TEST__
 

--- a/Client/UserOption.cpp
+++ b/Client/UserOption.cpp
@@ -15,23 +15,6 @@
 UserOption*		g_pUserOption = NULL;
 
 //----------------------------------------------------------------------
-// define functions
-//----------------------------------------------------------------------
-#define READ_CHECK_EOF( value, temp, bytes )		\
-		{											\
-			file.read((char*)&temp, bytes);			\
-			if (!file.eof())						\
-			{										\
-				value = temp;						\
-			}										\
-			else									\
-			{										\
-				file.close();						\
-				return true;						\
-			}										\
-		}
-
-//----------------------------------------------------------------------
 // 
 // constructor
 //
@@ -141,30 +124,6 @@ UserOption::SaveToFile(const char* filename)
 	fprintf(file, "%d	GammaValue\n", GammaValue);
 	fprintf(file, "%d	DrawChatBoxOutline\n", DrawChatBoxOutline);
 
-	// file.write((const char*)&UseSmoothCursor, 4);
-	// file.write((const char*)&DrawMinimap, 4);
-	// file.write((const char*)&DrawZoneName, 4);
-	// file.write((const char*)&DrawGameTime, 4);
-	// file.write((const char*)&DrawInterface, 4);
-	// file.write((const char*)&DrawFPS, 4);
-	// file.write((const char*)&BlendingShadow, 4);
-	// file.write((const char*)&FilteringCurse, 4);
-	// file.write((const char*)&PlayMusic, 4);
-	// file.write((const char*)&PlaySound, 4);
-	// file.write((const char*)&VolumeMusic, 4);
-	// file.write((const char*)&VolumeSound, 4);
-	// file.write((const char*)&UseHelpEvent, 4);
-	// file.write((const char*)&PlayWaveMusic, 4);
-	// file.write((const char*)&BloodDrop, 4);
-	// file.write((const char*)&OpenQuickSlot, 4);	
-	// file.write((const char*)&UseHalfFrame, 4);	
-	// file.write((const char*)&Use3DHAL, 4);
-	// file.write((const char*)&DrawTransHPBar, 4);	
-	// file.write((const char*)&UseForceFeel, 4);
-	// file.write((const char*)&UseGammaControl, 4);	
-	// file.write((const char*)&GammaValue, 4);	
-	// file.write((const char*)&DrawChatBoxOutline, 4);
-	
 	// new interface
 	fwrite((const void*)BackupID, 15, 1, file);
 	fprintf(file, "%d	UseEnterChat\n", UseEnterChat);
@@ -212,7 +171,6 @@ UserOption::LoadFromFile(const char* filename)
 //		g_pKeyAccelerator->SetAcceleratorKey(ACCEL_GRADE1INFO, DIK_R);
 //		file.seekg(-2, ios::cur);
 //	}
-
 
 	char ignore[256];
 	fscanf(file, "\n%s\n", ignore); // ignore =======

--- a/Client/UserOption.cpp
+++ b/Client/UserOption.cpp
@@ -6,6 +6,7 @@
 #include "UserOption.h"
 #include "KeyAccelerator.h"
 #include <DInput.h>
+#include <cstdio>
 
 
 //----------------------------------------------------------------------
@@ -109,64 +110,86 @@ UserOption::~UserOption()
 void	
 UserOption::SaveToFile(const char* filename)
 {
-	class ofstream file(filename, ios::binary);	
+	// class ofstream file(filename, ios::binary);	
+	FILE* file = fopen(filename, "w");
 
 	DWORD flag = 0;
-	file.write((const char*)&flag, 4);
+	fwrite((void*)&flag, 1, 4, file);
 	g_pKeyAccelerator->SaveToFile(file);
 
-	file.write((const char*)&UseSmoothCursor, 4);
-	file.write((const char*)&DrawMinimap, 4);
-	file.write((const char*)&DrawZoneName, 4);
-	file.write((const char*)&DrawGameTime, 4);
-	file.write((const char*)&DrawInterface, 4);
-	file.write((const char*)&DrawFPS, 4);
-	file.write((const char*)&BlendingShadow, 4);
-	file.write((const char*)&FilteringCurse, 4);
-	file.write((const char*)&PlayMusic, 4);
-	file.write((const char*)&PlaySound, 4);
-	file.write((const char*)&VolumeMusic, 4);
-	file.write((const char*)&VolumeSound, 4);
-	file.write((const char*)&UseHelpEvent, 4);
-	file.write((const char*)&PlayWaveMusic, 4);
-	file.write((const char*)&BloodDrop, 4);
-	file.write((const char*)&OpenQuickSlot, 4);	
-	file.write((const char*)&UseHalfFrame, 4);	
-	file.write((const char*)&Use3DHAL, 4);
-	file.write((const char*)&DrawTransHPBar, 4);	
-	file.write((const char*)&UseForceFeel, 4);
-	file.write((const char*)&UseGammaControl, 4);	
-	file.write((const char*)&GammaValue, 4);	
-	file.write((const char*)&DrawChatBoxOutline, 4);
+	fprintf(file, "\n========\n");
+
+	fprintf(file, "%d	UseSmoothCursor\n", UseSmoothCursor);
+	fprintf(file, "%d	DrawMinimap\n", DrawMinimap);
+	fprintf(file, "%d	DrawGameTime\n", DrawGameTime);
+	fprintf(file, "%d	DrawInterface\n", DrawInterface);
+	fprintf(file, "%d	DrawFPS\n", DrawFPS);
+	fprintf(file, "%d	BlendingShadow\n", BlendingShadow);
+	fprintf(file, "%d	FilteringCurse\n", FilteringCurse);
+	fprintf(file, "%d	PlayMusic\n", PlayMusic);
+	fprintf(file, "%d	PlaySound\n", PlaySound);
+	fprintf(file, "%d	VolumeMusic\n", VolumeMusic);
+	fprintf(file, "%d	VolumeSound\n", VolumeSound);
+	fprintf(file, "%d	UseHelpEvent\n", UseHelpEvent);
+	fprintf(file, "%d	PlayWaveMusic\n", PlayWaveMusic);
+	fprintf(file, "%d	BloodDrop\n", BloodDrop);
+	fprintf(file, "%d	OpenQuickSlot\n", OpenQuickSlot);
+	fprintf(file, "%d	UseHalfFrame\n", UseHalfFrame);
+	fprintf(file, "%d	Use3DHAL\n", Use3DHAL);
+	fprintf(file, "%d	DrawTransHPBar\n", DrawTransHPBar);
+	fprintf(file, "%d	UseForceFeel\n", UseForceFeel);
+	fprintf(file, "%d	GammaValue\n", GammaValue);
+	fprintf(file, "%d	DrawChatBoxOutline\n", DrawChatBoxOutline);
+
+	// file.write((const char*)&UseSmoothCursor, 4);
+	// file.write((const char*)&DrawMinimap, 4);
+	// file.write((const char*)&DrawZoneName, 4);
+	// file.write((const char*)&DrawGameTime, 4);
+	// file.write((const char*)&DrawInterface, 4);
+	// file.write((const char*)&DrawFPS, 4);
+	// file.write((const char*)&BlendingShadow, 4);
+	// file.write((const char*)&FilteringCurse, 4);
+	// file.write((const char*)&PlayMusic, 4);
+	// file.write((const char*)&PlaySound, 4);
+	// file.write((const char*)&VolumeMusic, 4);
+	// file.write((const char*)&VolumeSound, 4);
+	// file.write((const char*)&UseHelpEvent, 4);
+	// file.write((const char*)&PlayWaveMusic, 4);
+	// file.write((const char*)&BloodDrop, 4);
+	// file.write((const char*)&OpenQuickSlot, 4);	
+	// file.write((const char*)&UseHalfFrame, 4);	
+	// file.write((const char*)&Use3DHAL, 4);
+	// file.write((const char*)&DrawTransHPBar, 4);	
+	// file.write((const char*)&UseForceFeel, 4);
+	// file.write((const char*)&UseGammaControl, 4);	
+	// file.write((const char*)&GammaValue, 4);	
+	// file.write((const char*)&DrawChatBoxOutline, 4);
 	
 	// new interface
-	file.write((const char*)BackupID, 15);
-	file.write((const char*)&UseEnterChat, 4);
-	file.write((const char*)&UseMouseSpeed, 4);
-	file.write((const char*)&MouseSpeedValue, 4);
-	file.write((const char*)&PlayYellSound, 4);
-	file.write((const char*)&ShowChoboHelp, 4);
-	file.write((const char*)&TribeChange, 4);
-	file.write((const char*)&DenyPartyInvite, 4);
-	file.write((const char*)&DenyPartyRequest, 4);
-	file.write((const char*)&AutoHideSmoothScroll, 4);
-	file.write((const char*)&ChattingColor, 4);
-	file.write((const char*)&ALPHA_DEPTH, 1);
-	file.write((const char*)&DefaultAlpha, 4);
-	file.write((const char*)&IsPreLoadMonster, 4);
-	file.write((const char*)&ChatWhite, 4);
-	file.write((const char*)&UseTeenVersion, 4);
-	file.write((const char*)&PopupChatByWhisper, 4);
-	file.write((const char*)&NotSendMyInfo,4);
-	file.write((const char*)&DoNotShowWarMsg,4);
-	file.write((const char*)&DoNotShowLairMsg,4);
-	file.write((const char*)&DoNotShowHolyLandMsg,4);
-	file.write((const char*)&ShowGameMoneyWithHANGUL,4);
-	file.write((const char*)&DoNotShowPersnalShopMsg,4);
+	fwrite((const void*)BackupID, 15, 1, file);
+	fprintf(file, "%d	UseEnterChat\n", UseEnterChat);
+	fprintf(file, "%d	MouseSpeedValue\n", MouseSpeedValue);
+	fprintf(file, "%d	PlayYellSound\n", PlayYellSound);
+	fprintf(file, "%d	ShowChoboHelp\n", ShowChoboHelp);
+	fprintf(file, "%d	TribeChange\n", TribeChange);
+	fprintf(file, "%d	DenyPartyInvite\n", DenyPartyInvite);
+	fprintf(file, "%d	DenyPartyRequest\n", DenyPartyRequest);
+	fprintf(file, "%d	AutoHideSmoothScroll\n", AutoHideSmoothScroll);
+	fprintf(file, "%d	ChattingColor\n", ChattingColor);
+	fprintf(file, "%d	ALPHA_DEPTH\n", ALPHA_DEPTH);
+	fprintf(file, "%d	DefaultAlpha\n", DefaultAlpha);
+	fprintf(file, "%d	IsPreLoadMonster\n", IsPreLoadMonster);
+	fprintf(file, "%d	ChatWhite\n", ChatWhite);
+	fprintf(file, "%d	UseTeenVersion\n", UseTeenVersion);
+	fprintf(file, "%d	PopupChatByWhisper\n", PopupChatByWhisper);
+	fprintf(file, "%d	NotSendMyInfo\n", NotSendMyInfo);
+	fprintf(file, "%d	DoNotShowWarMsg\n", DoNotShowWarMsg);
+	fprintf(file, "%d	DoNotShowLairMsg\n", DoNotShowLairMsg);
+	fprintf(file, "%d	DoNotShowHolyLandMsg\n", DoNotShowHolyLandMsg);
+	fprintf(file, "%d	ShowGameMoneyWithHANGUL\n", ShowGameMoneyWithHANGUL);
+	fprintf(file, "%d	DoNotShowPersnalShopMsg\n", DoNotShowPersnalShopMsg);
 
-	
-
-	file.close();
+	fclose(file);
 }
 
 //----------------------------------------------------------------------
@@ -175,15 +198,13 @@ UserOption::SaveToFile(const char* filename)
 bool	
 UserOption::LoadFromFile(const char* filename)
 {
-	class ifstream file(filename, ios::binary | ios::nocreate);	
-
-	if (!file || !file.is_open())
-	{
+	FILE *file = fopen(filename, "r");
+	if (file == NULL) {
 		return false;
 	}
 	
 	DWORD flag = 0;
-	file.read((char*)&flag, 4);
+	fread((void*)&flag, 1, 4, file);
 	g_pKeyAccelerator->LoadFromFile(file);
 	
 //	if(flag == 0)
@@ -192,60 +213,56 @@ UserOption::LoadFromFile(const char* filename)
 //		file.seekg(-2, ios::cur);
 //	}
 
-	DWORD temp;
-	
-	READ_CHECK_EOF( UseSmoothCursor, temp, 4 );
-	READ_CHECK_EOF( DrawMinimap, temp, 4 );
-	READ_CHECK_EOF( DrawZoneName, temp, 4 );
-	READ_CHECK_EOF( DrawGameTime, temp, 4 );
-	READ_CHECK_EOF( DrawInterface, temp, 4 );
-	READ_CHECK_EOF( DrawFPS, temp, 4 );
-	READ_CHECK_EOF( BlendingShadow, temp, 4 );
-	READ_CHECK_EOF( FilteringCurse, temp, 4 );
-	READ_CHECK_EOF( PlayMusic, temp, 4 );
-	READ_CHECK_EOF( PlaySound, temp, 4 );
-	READ_CHECK_EOF( VolumeMusic, temp, 4 );
-	READ_CHECK_EOF( VolumeSound, temp, 4 );	
-	READ_CHECK_EOF( UseHelpEvent, temp, 4 );
-	READ_CHECK_EOF( PlayWaveMusic, temp, 4 );
-	READ_CHECK_EOF( BloodDrop, temp, 4 );	
-	READ_CHECK_EOF( OpenQuickSlot, temp, 4 );		
-	READ_CHECK_EOF( UseHalfFrame, temp, 4 );	
-	READ_CHECK_EOF( Use3DHAL, temp, 4);
-	READ_CHECK_EOF( DrawTransHPBar, temp, 4);	
-	READ_CHECK_EOF( UseForceFeel, temp, 4);	
-	READ_CHECK_EOF( UseGammaControl, temp, 4);		
-	READ_CHECK_EOF( GammaValue, temp, 4);	
-	READ_CHECK_EOF( DrawChatBoxOutline, temp, 4);
-	
+
+	char ignore[256];
+	fscanf(file, "\n%s\n", ignore); // ignore =======
+
+	fscanf(file, "%d	%s\n", &UseSmoothCursor, ignore);
+	fscanf(file, "%d	%s\n", &DrawMinimap, ignore);
+	fscanf(file, "%d	%s\n", &DrawGameTime, ignore);
+	fscanf(file, "%d	%s\n", &DrawInterface, ignore);
+	fscanf(file, "%d	%s\n", &DrawFPS, ignore);
+	fscanf(file, "%d	%s\n", &BlendingShadow, ignore);
+	fscanf(file, "%d	%s\n", &FilteringCurse, ignore);
+	fscanf(file, "%d	%s\n", &PlayMusic, ignore);
+	fscanf(file, "%d	%s\n", &PlaySound, ignore);
+	fscanf(file, "%d	%s\n", &VolumeMusic, ignore);
+	fscanf(file, "%d	%s\n", &VolumeSound, ignore);
+	fscanf(file, "%d	%s\n", &UseHelpEvent, ignore);
+	fscanf(file, "%d	%s\n", &PlayWaveMusic, ignore);
+	fscanf(file, "%d	%s\n", &BloodDrop, ignore);
+	fscanf(file, "%d	%s\n", &OpenQuickSlot, ignore);
+	fscanf(file, "%d	%s\n", &UseHalfFrame, ignore);
+	fscanf(file, "%d	%s\n", &Use3DHAL, ignore);
+	fscanf(file, "%d	%s\n", &DrawTransHPBar, ignore);
+	fscanf(file, "%d	%s\n", &UseForceFeel, ignore);
+	fscanf(file, "%d	%s\n", &GammaValue, ignore);
+	fscanf(file, "%d	%s\n", &DrawChatBoxOutline, ignore);
+
 	// new interface
-//	READ_CHECK_EOF( *BackupID, temp, 11);
-	file.read((char *)BackupID, 15);
-	READ_CHECK_EOF( UseEnterChat, temp, 4);
-	READ_CHECK_EOF( UseMouseSpeed, temp, 4);
-	READ_CHECK_EOF( MouseSpeedValue, temp, 4);
-	READ_CHECK_EOF( PlayYellSound, temp, 4);
-	READ_CHECK_EOF( ShowChoboHelp, temp, 4);
-	READ_CHECK_EOF( TribeChange, temp, 4);
-	READ_CHECK_EOF( DenyPartyInvite, temp, 4);
-	READ_CHECK_EOF( DenyPartyRequest, temp, 4);
-	READ_CHECK_EOF( AutoHideSmoothScroll, temp, 4);
-	READ_CHECK_EOF( ChattingColor, temp, 4);
-	READ_CHECK_EOF( ALPHA_DEPTH, temp, 1);
-	READ_CHECK_EOF( DefaultAlpha, temp, 4);
-	READ_CHECK_EOF( IsPreLoadMonster, temp, 4);
-	READ_CHECK_EOF( ChatWhite, temp, 4);
-	READ_CHECK_EOF( UseTeenVersion, temp, 4);
-	READ_CHECK_EOF( PopupChatByWhisper, temp, 4);
-	READ_CHECK_EOF( NotSendMyInfo, temp, 4);
-	READ_CHECK_EOF( DoNotShowWarMsg, temp, 4);
-	READ_CHECK_EOF( DoNotShowLairMsg, temp, 4);
-	READ_CHECK_EOF( DoNotShowHolyLandMsg, temp, 4);
-	READ_CHECK_EOF( ShowGameMoneyWithHANGUL, temp, 4);
-	READ_CHECK_EOF( DoNotShowPersnalShopMsg, temp, 4);
+	fread((void*)BackupID, 15, 1, file);
+	fscanf(file, "%d %s\n", &UseEnterChat, ignore);
+	fscanf(file, "%d %s\n", &MouseSpeedValue, ignore);
+	fscanf(file, "%d %s\n", &PlayYellSound, ignore);
+	fscanf(file, "%d %s\n", &ShowChoboHelp, ignore);
+	fscanf(file, "%d %s\n", &TribeChange, ignore);
+	fscanf(file, "%d %s\n", &DenyPartyInvite, ignore);
+	fscanf(file, "%d %s\n", &DenyPartyRequest, ignore);
+	fscanf(file, "%d %s\n", &AutoHideSmoothScroll, ignore);
+	fscanf(file, "%d %s\n", &ChattingColor, ignore);
+	fscanf(file, "%d %s\n", &ALPHA_DEPTH, ignore);
+	fscanf(file, "%d %s\n", &DefaultAlpha, ignore);
+	fscanf(file, "%d %s\n", &IsPreLoadMonster, ignore);
+	fscanf(file, "%d %s\n", &ChatWhite, ignore);
+	fscanf(file, "%d %s\n", &UseTeenVersion, ignore);
+	fscanf(file, "%d %s\n", &PopupChatByWhisper, ignore);
+	fscanf(file, "%d %s\n", &NotSendMyInfo, ignore);
+	fscanf(file, "%d %s\n", &DoNotShowWarMsg, ignore);
+	fscanf(file, "%d %s\n", &DoNotShowLairMsg, ignore);
+	fscanf(file, "%d %s\n", &DoNotShowHolyLandMsg, ignore);
+	fscanf(file, "%d %s\n", &ShowGameMoneyWithHANGUL, ignore);
+	fscanf(file, "%d %s\n", &DoNotShowPersnalShopMsg, ignore);
 
-	
-	file.close();
-
+	fclose(file);
 	return true;
 }

--- a/VS_UI/src/KeyAccelerator.cpp
+++ b/VS_UI/src/KeyAccelerator.cpp
@@ -6,6 +6,7 @@
 #include <fstream.h>
 #include "KeyAccelerator.h"
 #include "CDirectInput.h"
+#include <cstdio>
 //----------------------------------------------------------------------
 // define functions
 //----------------------------------------------------------------------
@@ -215,20 +216,19 @@ KeyAccelerator::GetKey(BYTE accel) const
 // Save To File
 //----------------------------------------------------------------------
 void				
-KeyAccelerator::SaveToFile(class ofstream& file)
+KeyAccelerator::SaveToFile(FILE *file)
 {
 	int num = m_Accelerators.capacity();
 
-	file.write((const char*)&num, 4);
+	fwrite((const void*)&num, 1, 4, file);
 
-	// key-accelerator의 관계만 저장하면 된다.
-	// 근데 accel은 순서대로이기 때메.. 저장할 필요없다.
-	// 그래서 key만 저장하면 된다.
+	// Only the key-accelerator relationship needs to be saved.
+	// Because accel is in order, so there is no need to save.
+	// So we only need to store the key.
 	for (int accel=1; accel<num; accel++)
 	{
 		WORD key = m_Accelerators[accel];
-
-		file.write((const char*)&key, 2);
+		fwrite((const void*)&key, 1, 2, file);
 	}
 }
 
@@ -236,10 +236,10 @@ KeyAccelerator::SaveToFile(class ofstream& file)
 // Load From File
 //----------------------------------------------------------------------
 void				
-KeyAccelerator::LoadFromFile(class ifstream& file)
+KeyAccelerator::LoadFromFile(FILE *file)
 {
 	int num;
-	file.read((char*)&num, 4);
+	fread((void*)&num, 1, 4, file);
 
 	Init( num );
 
@@ -247,9 +247,10 @@ KeyAccelerator::LoadFromFile(class ifstream& file)
 
 	for (int accel=1; accel<num; accel++)
 	{
-		file.read((char*)&key, 2);
-
-		if(!file.eof())
-			SetAcceleratorKey( accel , key );
+		int sz;
+		sz = fread((void*)&key, 1, 2, file);
+		if (sz == 2) {
+			SetAcceleratorKey(accel, key);
+		}
 	}
 }

--- a/VS_UI/src/header/KeyAccelerator.h
+++ b/VS_UI/src/header/KeyAccelerator.h
@@ -95,8 +95,8 @@ class KeyAccelerator {
 		//------------------------------------------------------------
 		// File I/O
 		//------------------------------------------------------------
-		void				SaveToFile(class ofstream& file);
-		void				LoadFromFile(class ifstream& file);
+		void				SaveToFile(FILE* file);
+		void				LoadFromFile(FILE* file);
 
 
 	protected :


### PR DESCRIPTION
Fix #23 

At first I was misled by the comment in https://github.com/opendarkeden/client/issues/23#issuecomment-921304696
It turned out to be here

https://github.com/opendarkeden/client/blob/6c87e2ec71a656a931cdceb615e718a91b1a1df4/Client/MPlayer.cpp#L9482-L9491

The `__METROTECH_TEST__` macro controls the behaviour of auto use potion, and that macro is defined here

https://github.com/opendarkeden/client/blob/6c87e2ec71a656a931cdceb615e718a91b1a1df4/Client/MTestDef.h#L11-L13

When building for Debug, `OUTPUT_DEBUG` is set, so `__METROTECH_TEST__` is set.

I've disable the `__METROTECH_TEST__` macro to avoid the auto potion using.

--------------------------

Another change is the UserOption file format, it's not human readable, so I slightly change it.
The format is not compatible with the old one, so if the game fail to start up, please remove the file `UserSet/UserOption.set` and retry.