### PR TITLE
Client: fix GCAddBat max packet size and fix DEBUG_ADD_FORMAT

### DIFF
--- a/Client/CMessageArray.cpp
+++ b/Client/CMessageArray.cpp
@@ -233,9 +233,9 @@ CMessageArray::AddFormatVL(const char* format, va_list& vl)
 //	va_list		vl;
 	static char Buffer[4096];
 
-    va_start(vl, format);
+//    va_start(vl, format);
 	vsprintf(Buffer, format, vl);    
-    va_end(vl);
+ //   va_end(vl);
 
 	int len = strlen(Buffer);
  

--- a/Client/Packet/Gpackets/GCAddBat.h
+++ b/Client/Packet/Gpackets/GCAddBat.h
@@ -138,7 +138,7 @@ public:
 			//+ szSpriteType 
 			//+ szColor + szColor
 			+ szCoord + szCoord + szDir
-			+ szHP
+			+ szHP*2
 			+ szGuildID
 			+ szColor
 			;


### PR DESCRIPTION
The HP should be MaxHP + CurrentHP, so the packet size should be HP*2
This fix the client panic when monster name size = 20