### PR TITLE
client: fix Deadly Claw skill display error

### DIFF
--- a/Client/MCreature.cpp
+++ b/Client/MCreature.cpp
@@ -9060,7 +9060,7 @@ MCreature::PacketSpecialActionToSector(TYPE_ACTIONINFO nActionInfo, TYPE_SECTORP
 		nActionInfo == SKILL_TRANSFUSION || nActionInfo == SKILL_PIERCING || nActionInfo == SKILL_VIOLENT_PHANTOM 
 		|| nActionInfo == SKILL_ICE_LANCE_MASTERY || nActionInfo == SKILL_ICE_LANCE
 		|| nActionInfo == SKILL_DESTRUCTION_SPEAR_MASTERY || nActionInfo == SKILL_DESTRUCTION_SPEAR
-		|| nActionInfo == SKILL_SPIT_STREAM || nActionInfo == SKILL_ROTTEN_APPLE 
+		|| nActionInfo == SKILL_SPIT_STREAM || nActionInfo == SKILL_ROTTEN_APPLE || nActionInfo == SKILL_VAMPIRE_INNATE_DEADLY_CLAW
 		)
 	{
 	//	DEBUG_ADD("hmhm");

--- a/standalone_version.md
+++ b/standalone_version.md
@@ -75,29 +75,19 @@ networks:
 
 
 ```
-docker-compose up -d
+docker-compose -f docker-compose.yml up -d
 ```
 
-登陆到容器
-
+启动服务器
 
 ```
-docker exec -it docker_odk-server_1  /bin/bash
+docker exec -it docker_odk-server_1  ./start.sh
 ```
-
-(或者直接从 Docker Desktop 里面点 cli)
-
-启动服务
-
-```sh
-./start.sh
-```
-
 
 如何关闭
 
 
 ```sh
-./stop.sh
+docker exec -it docker_odk-server_1  ./stop.sh
 docker-compose down
 ```


### PR DESCRIPTION
close #32

The cause of this bug is that the client does not handle the display correctly.
The client receive the SkillToTile5OK packet, then the code run to `MCreature::PacketSpecialActionToSector`,
and report such error:

```
		DEBUG_ADD_FORMAT("[Skill : %s] Target is Not Sector", (*g_pActionInfoTable)[nActionInfo].GetName());					
```



**A better fix should be change the `Data/Info/Action.inf` file**

The target of skill `SKILL_VAMPIRE_INNATE_DEADLY_CLAW`  should be TargetZone, so this condition returns true:

```
(*g_pActionInfoTable)[nActionInfo].IsTargetZone()
```

The file format is here:
https://github.com/opendarkeden/client/blob/891cdca26bf22a161d023ec03a74e06379977f5d/Client/MActionInfoTable.cpp#L295

In this commit I just use a workaround to fix it, because update the `Data/Info/Action.inf` involves more work.